### PR TITLE
Use "$COMPILER" in build-script/build.sh

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -173,7 +173,7 @@ then
     # fills the log with nonsense.
     TERM=dumb ./gradlew assembleExperimentalRelease -Pj=$num_jobs -Plocalize=false -Pabi_arm_32=false -Pabi_arm_64=true -Pdeps=/home/travis/build/CleverRaven/Cataclysm-DDA/android/app/deps.zip
 else
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 BACKTRACE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0
+    make -j "$num_jobs" CXX="$COMPILER" RELEASE=1 CCACHE=1 BACKTRACE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0
 
     if [ "$TRAVIS_OS_NAME" == "osx" ]
     then


### PR DESCRIPTION
#### Summary
SUMMARY: None


#### Purpose of change
Despite GitHub Action workflow `clang++-9` has the name, it uses `g++` under the hood. See log https://github.com/CleverRaven/Cataclysm-DDA/runs/1762135242

#### Describe the solution
`make CXX="$COMPILER"`

#### Describe alternatives you've considered
None.

#### Testing
Wait and see whether `clang++-9` workflow really uses `clang++-9`.
